### PR TITLE
Cache precompilation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           version: '1.9.0-rc1'
       - uses: julia-actions/cache@v1
+        with: 
+          cache-compiled: "true"
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install Julia dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'


### PR DESCRIPTION
This should cache the precompiled packages

See  warnings in    
https://github.com/julia-actions/cache

and 
https://github.com/julia-actions/cache/issues/11

